### PR TITLE
Suggestion for removing the client id from main().

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 #include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "soundcloud3000.h"
 #include "sds/sds.h"

--- a/main.c
+++ b/main.c
@@ -21,7 +21,7 @@ void handle_play(request *request) {
         write_error(request, "invalid url");
         return;
     }
-    
+
     track *track = api_get_track(&api, id);
 
     sds url = sdscatprintf(sdsempty(),  "%s?client_id=%s", track->stream_url, api.client_id);
@@ -54,7 +54,7 @@ void handle_user(request *request) {
         write_error(request, "invalid url");
         return;
     }
-    
+
     track_list *list = api_user_tracks(&api, permalink);
 
     if (list == NULL) {
@@ -67,25 +67,26 @@ void handle_user(request *request) {
     for (int i = 0; i < list->count; i++) {
         body = sdscatprintf(body, "<a href='/play/%d'>%s</li>", list->tracks[i].id, list->tracks[i].title);
     }
-    
+
     write_status(request, 200, "OK");
     write_header(request, "Content-Type", "text/html");
     write_body(request, body);
 }
 
-int main() {
+int main(int argc, char *argv[]) {
     api.host = "api.soundcloud.com";
-    api.client_id = "344564835576cb4df3cad0e34fa2fe0a";
+    /* who needs to sanitize or validate strings, anyhow? */
+    api.client_id = argv[1];
 
     audio_init();
 
     current_stream = stream_new();
-    
+
     server server;
     server.handlers = NULL;
-    server.address.sin_family = AF_INET;    
-    server.address.sin_addr.s_addr = INADDR_ANY;    
-    server.address.sin_port = htons(3000);    
+    server.address.sin_family = AF_INET;
+    server.address.sin_addr.s_addr = INADDR_ANY;
+    server.address.sin_port = htons(3000);
 
     add_handler(&server, "/user", handle_user);
     add_handler(&server, "/play", handle_play);

--- a/main.c
+++ b/main.c
@@ -75,8 +75,13 @@ void handle_user(request *request) {
 
 int main(int argc, char *argv[]) {
     api.host = "api.soundcloud.com";
-    /* who needs to sanitize or validate strings, anyhow? */
-    api.client_id = argv[1];
+
+    if (argc != 2 || strlen(argv[1]) >= CLIENT_ID_LENGTH) {
+      fprintf(stderr, "Usage: %s YOUR_CLIENT_ID\n", argv[0]);
+      exit(1);
+    } else {
+      strncpy(api.client_id, argv[1], CLIENT_ID_LENGTH);
+    }
 
     audio_init();
 

--- a/soundcloud3000.h
+++ b/soundcloud3000.h
@@ -2,9 +2,11 @@
 #include <portaudio.h>
 #include <mpg123.h>
 
+int const CLIENT_ID_LENGTH = 50;
+
 typedef struct api_config {
-    const char *host;
-    const char *client_id;
+  const char *host;
+  char client_id[CLIENT_ID_LENGTH];
 } api_config;
 
 typedef struct track {


### PR DESCRIPTION
I blame emacs for the whitespace clean up.
